### PR TITLE
Script optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ DerivedData/
 CompilationDatabase/
 compile_commands.json
 clang_analyze
+NootedRed/kern_fw.cpp.old

--- a/Scripts/FwGen.sh
+++ b/Scripts/FwGen.sh
@@ -1,19 +1,39 @@
 #!/bin/sh
 
+script_file="${PROJECT_DIR}/Scripts/GenerateFirmware.py"
 target_file="${PROJECT_DIR}/NootedRed/kern_fw.cpp"
-if [ -f "$target_file" ]; then
-    rm -f "$target_file"
-fi
-while [ $# -gt 0 ];
-do
-    case $1 in
-        -P) fw_files=$2
-            shift
-        ;;
 
+if ! command -v python3 &> /dev/null; then
+    echo "Python3 is not installed."
+    exit 1
+fi
+
+if [ -z "${PROJECT_DIR}" ] || [ ! -d "${PROJECT_DIR}" ]; then
+    PROJECT_DIR=$(pwd)
+    script_file="${PROJECT_DIR}/Scripts/GenerateFirmware.py"
+    target_file="${PROJECT_DIR}/NootedRed/kern_fw.cpp"
+    if [ ! -f "${script_file}" ]; then
+        echo "${script_file} is not exist."
+    fi
+fi
+echo "Project directory is: ${PROJECT_DIR}"
+
+if [ -f "$target_file" ]; then
+    mv -f "$target_file"{,.old}
+fi
+
+fw_files=""
+while getopts "P:" opt ; do
+    case $opt in
+        P)
+            fw_files=${OPTARG}
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            exit 1
+            ;;
     esac
-    shift
 done
 
-script_file="${PROJECT_DIR}/Scripts/GenerateFirmware.py"
+
 python3 "${script_file}" "${target_file}" "${fw_files}"

--- a/Scripts/GenerateFirmware.py
+++ b/Scripts/GenerateFirmware.py
@@ -2,6 +2,7 @@
 import os
 import struct
 import sys
+from pathlib import Path
 
 header = '''
 //  NootedRed
@@ -11,20 +12,16 @@ header = '''
 #include "kern_fw.hpp"
 '''
 
-
 def format_file_name(file_name):
     return file_name.replace(".", "_").replace("-", "_")
 
-
 def write_single_file(target_file, path, file):
-    src_file = open(path, "rb")
-    src_data = src_file.read()
-    src_len = len(src_data)
+    with open(path, "rb") as src_file:
+        src_data = src_file.read()
+        src_len = len(src_data)
 
     fw_var_name = format_file_name(file)
-    target_file.write("\nconst unsigned char ")
-    target_file.write(fw_var_name)
-    target_file.write("[] = {")
+    target_str = "\nconst unsigned char " + fw_var_name + "[] = {"
     index = 0
     block = []
     while True:
@@ -38,54 +35,41 @@ def write_single_file(target_file, path, file):
                 for b in block:
                     if type(b) is str:
                         b = ord(b)
-                    target_file.write("0x{:02X}, ".format(b))
-                target_file.write("\n")
+                    target_str += "0x{:02X}, ".format(b)
+                target_str += "\n"
             break
-        target_file.write("0x{:02X}, 0x{:02X}, 0x{:02X}, 0x{:02X}, "
+        target_str += ("0x{:02X}, 0x{:02X}, 0x{:02X}, 0x{:02X}, "
                           "0x{:02X}, 0x{:02X}, 0x{:02X}, 0x{:02X}, "
                           "0x{:02X}, 0x{:02X}, 0x{:02X}, 0x{:02X}, "
                           "0x{:02X}, 0x{:02X}, 0x{:02X}, 0x{:02X},\n"
                           .format(*struct.unpack("BBBBBBBBBBBBBBBB", block)))
-    target_file.write("};\n")
-    target_file.write("const long int ")
-    target_file.write(fw_var_name)
-    target_file.write("_size = sizeof(")
-    target_file.write(fw_var_name)
-    target_file.write(");\n")
-    src_file.close()
+    target_str += "};\n"
+    target_str += "const long int " + fw_var_name + "_size = sizeof(" + fw_var_name + ");\n"
+    target_file.write(target_str)
 
 
 def process_files(target_file, dir):
+    fw_desc_list = []
+
     if not os.path.exists(target_file):
         if not os.path.exists(os.path.dirname(target_file)):
-            os.mkdirs(os.path.dirname(target_file))
-    target_file_handle = open(target_file, "w")
-    target_file_handle.write(header)
-    for root, _dirs, files in os.walk(dir):
-        for file in files:
-            path = os.path.join(root, file)
-            write_single_file(target_file_handle, path, file)
+            os.makedirs(os.path.dirname(target_file))
 
-        target_file_handle.write("\n")
-        target_file_handle.write("const struct FwDesc fwList[] = {")
+    with open(target_file, "w") as target_file_handle:
+        target_file_handle.write(header)
+        for path in Path(dir).glob("**/*"):
+            if path.is_file():
+                file = path.name
+                write_single_file(target_file_handle, str(path), file)
+                fw_var_name = format_file_name(file)
+                fw_desc_list.append('{NRED_FW("' + file + '", ' + fw_var_name + ", " + fw_var_name + "_size)}")
 
-        for file in files:
-            target_file_handle.write('{NRED_FW("')
-            target_file_handle.write(file)
-            target_file_handle.write('", ')
-            fw_var_name = format_file_name(file)
-            target_file_handle.write(fw_var_name)
-            target_file_handle.write(", ")
-            target_file_handle.write(fw_var_name)
-            target_file_handle.write("_size)},\n")
-
-        target_file_handle.write("};\n")
-        target_file_handle.write("const int fwNumber = ")
-        target_file_handle.write(str(len(files)))
-        target_file_handle.write(";\n")
-
-    target_file_handle.close()
-
+        target_str = "\n"
+        target_str += "const struct FwDesc fwList[] = {" + ",\n".join(fw_desc_list) + "};\n"
+        target_str += "const int fwNumber = " + str(len(fw_desc_list)) + ";\n"
+        target_file_handle.write(target_str)
 
 if __name__ == '__main__':
+    if not os.path.exists(sys.argv[2]): 
+        exit(f"{sys.argv[2]} is not exist.")
     process_files(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
Scripts/FwGen.sh: run without Xcode environment, backup the `kern_fw.cpp` to `kern_fw.cpp.old`.

.gitignore: ignore backup
 
Scripts/GenerateFirmware.py
- replace `os.walk` with `pathlib.Path`, which is more modern and looks cleaner.
- avoid frequent I/O operations by saving data to list first and then writing them altogether.